### PR TITLE
Add jszip and bump version

### DIFF
--- a/lib/js-xlsx-rails/version.rb
+++ b/lib/js-xlsx-rails/version.rb
@@ -1,5 +1,5 @@
 module Jsxlsx
   module Rails
-    VERSION = "0.5.10"
+    VERSION = "0.7.7"
   end
 end

--- a/vendor/assets/javascripts/xlsx.js
+++ b/vendor/assets/javascripts/xlsx.js
@@ -1,1 +1,2 @@
+../../../js-xlsx/jszip.js
 ../../../js-xlsx/xlsx.js


### PR DESCRIPTION
As far as I can tell, jszip is required for js-xlsx: https://github.com/SheetJS/js-xlsx#installation.
