### PR TITLE
Use standalone distro per @SheetJSDev suggestion

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ namespace :assets do
   task :copy do
     sh 'git submodule update --init' unless File.exist?('js-xlsx/xlsx.js')
     mkdir_p 'vendor/assets/javascripts'
-    cp 'js-xlsx/xlsx.js',  'vendor/assets/javascripts/'
-    cp 'js-xlsx/jszip.js',  'vendor/assets/javascripts/'
+    cp 'js-xlsx/dist/xlsx.core.min.js',  'vendor/assets/javascripts/'
   end
 end

--- a/vendor/assets/javascripts/jszip.js
+++ b/vendor/assets/javascripts/jszip.js
@@ -1,1 +1,0 @@
-../../../js-xlsx/jszip.js

--- a/vendor/assets/javascripts/xlsx.js
+++ b/vendor/assets/javascripts/xlsx.js
@@ -1,1 +1,1 @@
-../../../js-xlsx/xlsx.js
+../../../js-xlsx/dist/xlsx.core.min.js


### PR DESCRIPTION
This is per @SheetJSDev suggestion:

> The distribution has standalone single-file versions such as https://github.com/SheetJS/js-xlsx/blob/master/dist/xlsx.core.min.js

I guess you need to be good with the `jszip` requirement not being obvious and that this uses a minified file.
